### PR TITLE
Fix Missing Early Classes and Enhance Preference Matching Logic

### DIFF
--- a/src/main/resources/static/scr/timetablebuilder.js
+++ b/src/main/resources/static/scr/timetablebuilder.js
@@ -55,7 +55,7 @@ $(document).ready(function () {
 
 var times = [];
 $(document).ready(function () {
-  for (var i = 9; i <= 21; i++) {
+  for (var i = 8; i <= 21; i++) {
     if (i < 10) {
       times.push("0" + i + ":00");
       times.push("0" + i + ":30");
@@ -456,7 +456,7 @@ function initTimetableTemplat(timetableFall, timetableWinter) {
     5: "",
   };
   // 生成课表模板
-  for (var i = 9; i <= 21; i++) {
+  for (var i = 8; i <= 21; i++) {
     if (i < 10) {
       timetableFall["0" + i + ":00"] = Object.assign({}, dayTemplate);
       timetableWinter["0" + i + ":00"] = Object.assign({}, dayTemplate);


### PR DESCRIPTION
## Summary

This pull request resolves issues related to timetable generation and course scheduling logic, specifically addressing early class times and strict result filtering based on user preferences.

## Detailed Changes

1. **Support for 8:00am Class Start Times**
   - Previously, the timetable assumed that classes start at 9:00am, causing 8:00am classes to be omitted and sometimes crashing the backend.
   - The timetable start time has now been adjusted to 8:00am to properly support and render early classes such as CSC108H5.

2. **Flexible Preference Matching Logic**
   - The previous logic only included schedules that met a strict preference threshold (`user preference`) in the final result queue.
   - This strict filter could lead to cases where no timetable was generated at all, even when conflict-free schedules existed.
   - The updated logic removes this threshold: schedules that are the closest to the user’s preferences will now be included, ensuring that at least one valid schedule is always returned as long as there are no conflicts.

## Modified Files

- `src/main/java/com/uoftbox/uofttimetablebuilder/service/TimetableGeneratService.java`
- `src/main/resources/static/src/timetablebuilder.js`

## Related Issue

- Closes #57 
